### PR TITLE
Fix crash when no torrents

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -65,7 +65,9 @@ class App extends Component {
                         </p>
 
                         <p className="primary quality">
-                            {qualities.reduce((prev, current) => `${current}/${prev}`)}
+                            {qualities.length
+                                ? qualities.reduce((prev, current) => `${current}/${prev}`)
+                                : '-'}
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
There was a crash happening when the API responded with no torrents.

I've adjusted so that a '-' is shown instead of the resolutions.